### PR TITLE
Rhythmbox 3.0.x compatibility: use python3

### DIFF
--- a/ConfigDialog.py
+++ b/ConfigDialog.py
@@ -42,14 +42,14 @@ class ConfigDialog(Gtk.Dialog):
         self.GConf_plugin_path = GConf_plugin_path
         self.desktop_control = desktop_control
         self.plugin = plugin
-        
+
         self.widgets = {}
         self.get_widgets(self.widgets, glade_file)
         self.set_callbacks(self.widgets)
 
         self.vbox.add(self.widgets['main_area'])
         self.widgets['main_area'].set_border_width(6)
-        
+
         self.set_resizable(False)
 
     def get_widgets(self, w, glade_file):
@@ -88,7 +88,7 @@ class ConfigDialog(Gtk.Dialog):
                 rgba = self.gc.get_string(self.GConf_path(name))
                 _, color = Gdk.Color.parse( rgba[:-4] )
                 a = int(rgba[-4:], 16)
-                w[name].set_color(color)  
+                w[name].set_color(color)
                 w[name].set_alpha(a)
             elif isinstance(w[name], Gtk.FontButton):
                 fontname = self.gc.get_string(self.GConf_path(name))

--- a/CoverManager.py
+++ b/CoverManager.py
@@ -33,7 +33,7 @@ import rb
 from gi.repository import Gtk, GObject
 
 from os import path, listdir
-from urllib import url2pathname
+from urllib.request import url2pathname
 
 IMAGE_NAMES = ['cover', 'album', 'albumart', '.folder', 'folder']
 STORAGE_LOC = "~/.gnome2/rhythmbox/covers/"
@@ -49,17 +49,17 @@ class CoverManager():
     def get_cover(self, db_entry=None):
         # Find cover in music dir
         if db_entry:
-            print "dbentry"
+            print("dbentry")
             cover_dir = path.dirname(url2pathname(db_entry.get_playback_uri()).replace('file://', ''))
             if path.isdir(cover_dir):
-                print cover_dir
+                print(cover_dir)
                 for f in listdir(cover_dir):
                     file_name = path.join(cover_dir, f)
                     mt = mimetypes.guess_type(file_name)[0]
                     if mt and mt.startswith('image/'):
                         if path.splitext(f)[0].lower() in IMAGE_NAMES:
-                            print "spli"
-                            print file_name
+                            print("spli")
+                            print(file_name)
                             return file_name
 
             # Find cover saved by artdisplay plugin
@@ -72,8 +72,8 @@ class CoverManager():
                                             song_info['album'],
                                             file_type))
                     if path.isfile(cover_file):
-                        print "Found image in cache folder"
-                        print cover_file
+                        print("Found image in cache folder")
+                        print(cover_file)
                         return cover_file
 
             key = db_entry.create_ext_db_key(RB.RhythmDBPropType.ALBUM)
@@ -81,7 +81,7 @@ class CoverManager():
             art_location = cover_db.lookup(key)
 
             if art_location and path.exists(art_location):
-                print art_location
+                print(art_location)
                 return art_location
             # Find the image from AlbumArt plugin
             #cover_art = self.db.entry_request_extra_metadata(db_entry, "rb:coverArt")
@@ -90,21 +90,21 @@ class CoverManager():
             #if cover_art==None:
             #    print "Image not found, bloody timeouts"
             #    return DesktopControl.UNKNOWN_COVER
-    
+
                 # Do the dirty work here
                 cover_file = path.expanduser(STORAGE_LOC) + song_info['title'] + "-" + song_info['artist'] + ".jpg"
-                print cover_file
+                print(cover_file)
                 cover_art.save(cover_file, "jpeg", {"quality":"100"})
-                print "Returning cover file"
-                print cover_file
+                print("Returning cover file")
+                print(cover_file)
                 return cover_file
-            
+
 
             # No cover found
-            print "no cover"
+            print("no cover")
             return DesktopControl.UNKNOWN_COVER
         # Not playing
-        print "not playing"
+        print("not playing")
         return None
 
     def get_song_info(self, db_entry=None):

--- a/DefaultGConfValues.py
+++ b/DefaultGConfValues.py
@@ -44,7 +44,7 @@ def GConf_path(key):
 
 gc = GConf.Client.get_default()
 
-for key, val in defaults.items():
+for key, val in list(defaults.items()):
     path = GConf_path(key)
     if gc.get_without_default(path) == None:
         if isinstance(val, bool):
@@ -56,4 +56,4 @@ for key, val in defaults.items():
         elif isinstance(val, str):
             gc.set_string(path, val)
         else:
-            print 'Datatype %s is not supported' % type(val)
+            print('Datatype %s is not supported' % type(val))

--- a/DesktopControl.py
+++ b/DesktopControl.py
@@ -18,7 +18,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from __future__ import division
+
 
 #import sys
 from gi.repository import GObject
@@ -40,37 +40,37 @@ POSITION_SE = 'se'
 GConf_plugin_path = '/apps/rhythmbox/plugins/desktop-art'
 
 def get_icon_path(theme, name, size):
-    print "get_icon_path"
+    print("get_icon_path")
     icon = theme.lookup_icon(name, size, Gtk.IconLookupFlags.FORCE_SVG)
     return (icon and icon.get_filename())
 
 def GConf_path(key):
-    print "GConf_path"
+    print("GConf_path")
     return '%s/%s' % (GConf_plugin_path, key)
 
 def read_GConf_values(values, keys):
-    print "read_GConf_values"
+    print("read_GConf_values")
     gc = GConf.Client.get_default()
     for key in keys:
         val = gc.get_without_default(GConf_path(key))
         if val:
-			if val.type == GConf.ValueType.FLOAT:
-				values[key] = val.get_float()
-			elif val.type == GConf.ValueType.INT:
-				values[key] = val.get_int()
-			elif val.type == GConf.ValueType.STRING:
-				values[key] = val.get_string()
-			elif val.type == GConf.ValueType.BOOL:
-				values[key] = val.get_bool()
-			# Parse color strings
-			if 'color' in key:
-				values['%s_r' % key] = int(values[key][ 1: 5], 16) / int('ffff', 16)
-				values['%s_g' % key] = int(values[key][ 5: 9], 16) / int('ffff', 16)
-				values['%s_b' % key] = int(values[key][ 9:13], 16) / int('ffff', 16)
-				values['%s_a' % key] = int(values[key][13:17], 16) / int('ffff', 16)
+            if val.type == GConf.ValueType.FLOAT:
+                values[key] = val.get_float()
+            elif val.type == GConf.ValueType.INT:
+                values[key] = val.get_int()
+            elif val.type == GConf.ValueType.STRING:
+                values[key] = val.get_string()
+            elif val.type == GConf.ValueType.BOOL:
+                values[key] = val.get_bool()
+            # Parse color strings
+            if 'color' in key:
+                values['%s_r' % key] = int(values[key][ 1: 5], 16) / int('ffff', 16)
+                values['%s_g' % key] = int(values[key][ 5: 9], 16) / int('ffff', 16)
+                values['%s_b' % key] = int(values[key][ 9:13], 16) / int('ffff', 16)
+                values['%s_a' % key] = int(values[key][13:17], 16) / int('ffff', 16)
 
 def reread_GConf_value(conf, keys, key):
-    print "reread_GConf_value"
+    print("reread_GConf_value")
     if key in keys:
         read_GConf_values(conf, [key])
 
@@ -128,7 +128,7 @@ class DesktopControl(Gtk.DrawingArea):
         #gc.notify_add('/apps/nautilus/preferences/desktop_font', self.font_changed, [self.song_info])
 
         #gc.add_dir(GConf_plugin_path, GConf.ClientPreloadType.PRELOAD_NONE)
-        
+
         self.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK | Gdk.EventMask.POINTER_MOTION_MASK | Gdk.EventMask.BUTTON_PRESS_MASK)
         self.mouse_over = False
         self.hover_time_out = None
@@ -145,21 +145,21 @@ class DesktopControl(Gtk.DrawingArea):
         gc.notify_add(GConf_plugin_path+'/text_font', self.font_changed, [self.song_info])
 
     def set_GConf_callbacks(self, affected):
-        print "set_GConf_callbacks"
+        print("set_GConf_callbacks")
         gc = GConf.Client.get_default()
         for entry in gc.all_entries(GConf_plugin_path):
-            print entry
+            print(entry)
             path = entry.get_key()
-            print path
+            print(path)
             key = path.split('/')[-1]
-            print key
+            print(key)
             gc.notify_add(path, self.GConf_cb, {'key': key, 'affected': affected})
-            print "end set_GConf_callbacks"
+            print("end set_GConf_callbacks")
 
     def GConf_cb(self, client, cnxn_id, entry, ud):
-        print "GConf_cb"
+        print("GConf_cb")
         for af in ud['affected']:
-            print "affected"
+            print("affected")
             reread_GConf_value(af.conf, af.GConf_keys, ud['key'])
         self.queue_draw()
 
@@ -198,7 +198,7 @@ class DesktopControl(Gtk.DrawingArea):
             self.queue_draw()
 
     def draw_cb(self, widget, cc):
-        print "do_draw_cb"
+        print("do_draw_cb")
         # Clear cairo context
         cc.set_source_rgba(0, 0, 0, 0)
         cc.set_operator(cairo.OPERATOR_SOURCE)
@@ -236,7 +236,7 @@ class DesktopControl(Gtk.DrawingArea):
                 cc.restore()
         if self.mouse_over:
             cc.restore()
-            
+
         graphics = cc.pop_group()
 
         # Draw main graphics
@@ -253,21 +253,21 @@ class DesktopControl(Gtk.DrawingArea):
                 if(self.cover_image.w > self.cover_image.h):
                     cc.save()
                     cc.translate(0, 2 * (self.cover_image.h - self.cover_image.w) / self.cover_image.w)
-                    
+
             cc.scale(1, -1)
             cc.push_group()
             x_scale = cc.get_matrix()[0]
             r1 = int(self.conf['blur'] / 2 + 1.5)
             r0 = r1 - self.conf['blur'] - 1
             bn = (self.conf['blur'] + 1)**2
-            for dx in xrange(r0, r1):
-                for dy in xrange(r0, r1):
+            for dx in range(r0, r1):
+                for dy in range(r0, r1):
                     cc.save()
                     cc.translate(dx/x_scale, dy/x_scale)
                     cc.set_source(graphics)
                     cc.paint_with_alpha(1/bn)
                     cc.restore()
-                    
+
             graphics = cc.pop_group()
             cc.set_source(graphics)
             shadow_mask = cairo.LinearGradient(0, 1 - self.conf['reflection_height'], 0, 1)
@@ -277,7 +277,7 @@ class DesktopControl(Gtk.DrawingArea):
             if (self.conf['text_position'] in [POSITION_NW, POSITION_NE]) and (not self.mouse_over):
                 if(self.cover_image.w > self.cover_image.h):
                     cc.restore()
-                    
+
             cc.restore()
 
         # Input mask, only the cover image is clickable
@@ -297,10 +297,10 @@ class DesktopControl(Gtk.DrawingArea):
             self.get_parent().input_shape_combine_region(region)
         except:
             pass
-            
+
         # Draw border
         if self.draw_border:
-            print "drawborder"
+            print("drawborder")
             cc.identity_matrix()
             cc.rectangle(0, 0, rect.width, rect.height)
             cc.set_line_width(2)
@@ -407,7 +407,7 @@ class DesktopButtons():
                 self.player.do_previous()
             except:
                 pass
-                
+
             return True
         elif self.idata[('play', 'hover')]:
             self.player.playpause(True)
@@ -417,7 +417,7 @@ class DesktopButtons():
                 self.player.do_next()
             except:
                 pass
-                
+
             return True
         return False
 
@@ -434,7 +434,7 @@ class DesktopButtons():
         return redraw
 
     def icon_theme_changed(self, icon_theme):
-        print "icon_theme_changed"
+        print("icon_theme_changed")
         for k in self.icon_keys:
             self.idata[(k, 'icon_path')] = get_icon_path(icon_theme, self.icons[k], self.icons['size'])
             try:
@@ -449,7 +449,7 @@ class DesktopButtons():
                     self.idata[(k, 'h')]     = self.idata[(k, 'image')].get_height()
                     self.idata[(k, 'draw')]  = self.draw_pixbuf_icon
                 except:
-                    print "error no media icons"
+                    print("error no media icons")
                     sys.exit('ERROR: No media icons found.')
             self.idata[(k, 'dim')]   = max(self.idata[(k, 'w')], self.idata[(k, 'h')])
             self.idata[(k, 'scale')] = 1 / self.idata[(k, 'dim')]
@@ -567,7 +567,7 @@ class CoverImage():
             self.x = (self.dim - self.w) / 2
             self.y = self.dim - self.h
             self.scale = 1 / self.dim
-            
+
         self.current_image = image
 
     def draw_background(self, cc, size = None):
@@ -603,7 +603,7 @@ class CoverImage():
         cc.fill_preserve()
         cc.set_operator(cairo.OPERATOR_OVER)
         cc.scale(1/img_scale, 1/img_scale)
-        
+
         #cc.set_source_pixbuf(scaled_image, img_scale * self.x, img_scale * self.y)
         Gdk.cairo_set_source_pixbuf(cc, scaled_image, img_scale * self.x, img_scale * self.y)
         cs = cc.get_source()

--- a/IdleTimer.py
+++ b/IdleTimer.py
@@ -27,27 +27,27 @@ import ctypes
 import os
 
 class XScreenSaverInfo(ctypes.Structure):
-  _fields_ = [('window',      ctypes.c_ulong), # screen saver window
-              ('state',       ctypes.c_int),   # off,on,disabled
-              ('kind',        ctypes.c_int),   # blanked,internal,external
-              ('since',       ctypes.c_ulong), # milliseconds
-              ('idle',        ctypes.c_ulong), # milliseconds
-              ('event_mask',  ctypes.c_ulong)] # events
-  
-class IdleTimer():
-  def __init__(self):
-    self.xlib = ctypes.cdll.LoadLibrary('libX11.so')
-    self.dpy = self.xlib.XOpenDisplay(os.environ['DISPLAY'])
-    self.root = self.xlib.XDefaultRootWindow(self.dpy)
-    self.xss = ctypes.cdll.LoadLibrary('libXss.so')
-    self.xss.XScreenSaverAllocInfo.restype = ctypes.POINTER(XScreenSaverInfo)
-    self.xss_info = self.xss.XScreenSaverAllocInfo()
+    _fields_ = [('window',      ctypes.c_ulong), # screen saver window
+                ('state',       ctypes.c_int),   # off,on,disabled
+                ('kind',        ctypes.c_int),   # blanked,internal,external
+                ('since',       ctypes.c_ulong), # milliseconds
+                ('idle',        ctypes.c_ulong), # milliseconds
+                ('event_mask',  ctypes.c_ulong)] # events
 
-  def getIdleTime(self):
-    self.xss.XScreenSaverQueryInfo(self.dpy, self.root, self.xss_info)
-    return self.xss_info.contents.idle
+class IdleTimer():
+    def __init__(self):
+        self.xlib = ctypes.cdll.LoadLibrary('libX11.so')
+        self.dpy = self.xlib.XOpenDisplay(os.environ['DISPLAY'])
+        self.root = self.xlib.XDefaultRootWindow(self.dpy)
+        self.xss = ctypes.cdll.LoadLibrary('libXss.so')
+        self.xss.XScreenSaverAllocInfo.restype = ctypes.POINTER(XScreenSaverInfo)
+        self.xss_info = self.xss.XScreenSaverAllocInfo()
+
+    def getIdleTime(self):
+        self.xss.XScreenSaverQueryInfo(self.dpy, self.root, self.xss_info)
+        return self.xss_info.contents.idle
 
 if __name__== '__main__':
-  it = IdleTimer()
-  while True:
-    print it.getIdleTime()
+    it = IdleTimer()
+    while True:
+        print(it.getIdleTime())

--- a/desktop-art.plugin
+++ b/desktop-art.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=desktop-art
 IAge=2
 Depends=rb

--- a/desktop-art.py
+++ b/desktop-art.py
@@ -46,7 +46,7 @@ class DesktopArt(GObject.Object, Peas.Activatable):
 
     __gtype_name = 'DesktopArtPlugin'
     object = GObject.property(type=GObject.Object)
-    
+
     def __init__ (self):
         GObject.Object.__init__ (self)
 
@@ -55,10 +55,10 @@ class DesktopArt(GObject.Object, Peas.Activatable):
         ui.add_from_file(rb.find_plugin_file(self,
             'desktop-art.ui'))
         window =  ui.get_object('window')
-        window.set_app_paintable(True)  
+        window.set_app_paintable(True)
         screen = window.get_screen()
         visual = screen.get_rgba_visual()
-            
+
         self.composited = window.is_composited()
         if visual !=None and self.composited:
             window.set_visual(visual)
@@ -67,15 +67,15 @@ class DesktopArt(GObject.Object, Peas.Activatable):
             window.stick()
             window.set_keep_below(True)
 
-            desktop_control = DesktopControl(icons, self.shell, player, 
-				rb.find_plugin_file(self,'configure-art.ui'), self)
+            desktop_control = DesktopControl(icons, self.shell, player,
+                                rb.find_plugin_file(self,'configure-art.ui'), self)
             cover_manager = CoverManager(player.props.db)
             #player.props.db.connect_after("entry-extra-metadata-notify::rb:coverArt-uri", self.notify_metadata)
 
             gc = GConf.Client.get_default()
             gc.add_dir(GConf_plugin_path, GConf.ClientPreloadType.PRELOAD_NONE)
             window_props = self.get_GConf_window_props(gc)
-            
+
             self.gc_notify_ids = [gc.notify_add(self.GConf_path('window_x'), self.GConf_cb, window_props),
                                   gc.notify_add(self.GConf_path('window_y'), self.GConf_cb, window_props),
                                   gc.notify_add(self.GConf_path('window_w'), self.GConf_cb, window_props),
@@ -92,9 +92,9 @@ class DesktopArt(GObject.Object, Peas.Activatable):
             self.desktop_control = desktop_control
             self.cover_manager = cover_manager
 
-            print "Adding timeout"
+            print("Adding timeout")
             ret = GObject.timeout_add(POLL_TIMEOUT, self.poll_for_coverart)
-            print "integer id returned: " + str(ret)
+            print("integer id returned: " + str(ret))
 
             self.position_window(self.window_props)
             self.window.show_all()
@@ -137,12 +137,12 @@ class DesktopArt(GObject.Object, Peas.Activatable):
             return True
         else:
             self.desktop_control.set_song(self.player.get_playing(), c, s)
-            return False          
+            return False
 
     # Subscribe to metadata notification
     # TODO: Not working - notification coming too soon
     def notify_metadata(self, db, entry, field=None,metadata=None):
-        print "Metadata changed changed"
+        print("Metadata changed changed")
         if entry:
             c, s = self.cover_manager.get_cover_and_song_info(entry)
             self.desktop_control.set_song(self.player.get_playing(), c, s)

--- a/roundedrec.py
+++ b/roundedrec.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 
 def roundedrec(cc, x, y, w, h, r):
     r = min(1,r)


### PR DESCRIPTION
Hi again :-)

the new rhythmbox 3.0 release ( http://ftp.acc.umu.se/pub/GNOME/sources/rhythmbox/3.0/ ) 
uses python3 for plugins ( see http://ftp.acc.umu.se/pub/GNOME/sources/rhythmbox/3.0/rhythmbox-3.0.news ).

I used 2to3 to make sure all python scripts are compatible with python3 and reindent.py to fix indentations afterwards.
