### PR TITLE
playpause() no longer seems to accept any arguments.

### DIFF
--- a/DesktopControl.py
+++ b/DesktopControl.py
@@ -417,7 +417,7 @@ class DesktopButtons():
 
             return True
         elif self.idata[('play', 'hover')]:
-            self.player.playpause(True)
+            self.player.playpause()
             return True
         elif self.idata[('next', 'hover')]:
             try:


### PR DESCRIPTION
When trying to use the Play button, nothing would happen and this would show up in the console output.
```
Traceback (most recent call last):
  File "/home/tatokis/.local/share/rhythmbox/plugins/desktop-art/DesktopControl.py", line 169, in button_press
    if not affected.button_press():
  File "/home/tatokis/.local/share/rhythmbox/plugins/desktop-art/DesktopControl.py", line 420, in button_press
    self.player.playpause()
TypeError: RB.ShellPlayer.playpause() takes exactly 1 argument (2 given)
```
Reading up on the RB3 binding docs, it appears that in the past, any arguments passed to playpause() were discarded.
This commit fixes the issue.